### PR TITLE
Added support for creating wrapper elements using functions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,31 @@ function listItem(n: number) {
 </ul>
 ```
 
+#### Using a helper template like an element
+
+Want a helper component? Create a function that implements CustomElementHandler and you can call it like an HTML element. 
+
+```typescript
+import {Attributes, CustomElementHandler} from "typed-html"
+
+function Button(attributes: Attributes | undefined, contents: string[]) {
+    return <div><button type="button" class="original-class" {...attributes}>{contents}</button></div>;
+}
+// Or 
+const Button: CustomElementHandler = (attributes, contents) => <div><button type="button" class="original-class" {...attributes}>{contents}</button></div>;
+}
+    
+console.log(<Button style="color:#f00">Button Text</Button>);
+```
+
+Prints: 
+
+```html
+<div>
+    <button type="button" class="original-class" style="color:#f00">Button Text</button>
+</div>
+```
+
 ## Supported HTML
 
 All HTML elements and attributes are supported, except for the [svg](https://www.w3.org/TR/SVG/).

--- a/src/elements.tsx
+++ b/src/elements.tsx
@@ -4,6 +4,16 @@
 
 import * as os from 'os';
 
+type AttributeValue = number | string | Date | boolean;
+
+export interface CustomElementHandler {
+    (attributes: Attributes | undefined, contents: string[]): string
+}
+
+export interface Attributes {
+    [key: string]: AttributeValue;
+}
+
 const capitalACharCode = 'A'.charCodeAt(0);
 const capitalZCharCode = 'Z'.charCodeAt(0);
 
@@ -11,12 +21,6 @@ const isUpper = (input: string, index: number) => {
     const charCode = input.charCodeAt(index);
     return capitalACharCode <= charCode && capitalZCharCode >= charCode;
 };
-
-type AttributeValue = number | string | Date | boolean;
-
-interface Attributes {
-    [key: string]: AttributeValue;
-}
 
 const toKebabCase = (camelCased: string) => {
     let kebabCased = '';
@@ -103,11 +107,17 @@ const isVoidElement = (tagName: string) => {
     ].indexOf(tagName) > -1;
 };
 
-export function createElement(name: string, attributes: Attributes | undefined, ...contents: string[]) {
-    const tagName = toKebabCase(name);
-    if (isVoidElement(tagName) && !contents.length) {
-        return `<${tagName}${attributesToString(attributes)}>`;
+export function createElement(name: string | CustomElementHandler,
+                              attributes: Attributes | undefined,
+                              ...contents: string[]) {
+    if (typeof name === 'function') {
+        return name(attributes, contents);
     } else {
-        return `<${tagName}${attributesToString(attributes)}>${contentsToString(contents)}</${tagName}>`;
+        const tagName = toKebabCase(name);
+        if (isVoidElement(tagName) && !contents.length) {
+            return `<${tagName}${attributesToString(attributes)}>`;
+        } else {
+            return `<${tagName}${attributesToString(attributes)}>${contentsToString(contents)}</${tagName}>`;
+        }
     }
 }

--- a/test/html-fragments.spec.tsx
+++ b/test/html-fragments.spec.tsx
@@ -80,3 +80,15 @@ describe('custom elements', () => {
     testEqual('<custom-element a-custom-attr="value" custom-li-attr="li"></custom-element>', () => <customElement ACustomAttr="value" customLIAttr="li"></customElement>);
     testEqual('<div some-data="s"></div>', () => <div some-data="s"></div>);
 });
+
+describe('helper components', () => {
+    const Header: elements.CustomElementHandler = (attributes, contents) => <h1 {...attributes}>{contents}</h1>;
+
+    function Button(attributes: elements.Attributes | undefined, contents: string[]) {
+        return <button type='button' class='original-class' {...attributes}>{contents}</button>;
+    }
+
+    testEqual('<h1 class="title"><span>Header Text</span></h1>', () => <Header class='title'><span>Header Text</span></Header>);
+    testEqual('<button class="override" type="button"></button>', () => <Button class='override'/>);
+    testEqual('<button class="original-class" type="button">Button Text</button>', () => <Button>Button Text</Button>);
+});


### PR DESCRIPTION
Hi,

I wanted to add support for Stateless components like React allows as seen in the first example here .
https://reactjs.org/docs/components-and-props.html

 It was basically just a one line fix to check if the createElements callback was getting a function or not. I couldn't get the interface to look exactly like in React since it does fancier stuff to sort out props and children elements. So to avoid a children attribute showing up in all the elements, I added a second parameter specifically for that.

I added tests and reran against the existing suite.
