### PR TITLE
feat - Support React-style children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-### Features
-
-* Support React-style `children` within `elements.Attributes`.
-
 # [2.0.0](https://github.com/nicojs/typed-html/compare/v1.0.0...v2.0.0) (2019-06-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Features
+
+* Support React-style `children` within `elements.Attributes`.
+
 # [2.0.0](https://github.com/nicojs/typed-html/compare/v1.0.0...v2.0.0) (2019-06-27)
 
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,28 @@ Prints:
 </div>
 ```
 
+#### React-style children
+
+It's possible to write React-style components as well. Consider the example below.
+
+```typescript
+import {Attributes, CustomElementHandler} from "typed-html"
+
+function Button({ children, ...attributes }: Attributes) {
+    return <div><button type="button" class="original-class" {...attributes}>{children}</button></div>;
+}
+
+console.log(<Button style="color:#f00">Button Text</Button>);
+```
+
+Prints:
+
+```html
+<div>
+    <button type="button" class="original-class" style="color:#f00">Button Text</button>
+</div>
+```
+
 ## Sanitization
 
 Security is *NOT* a feature. This library does *NOT* sanitize.

--- a/src/elements.tsx
+++ b/src/elements.tsx
@@ -3,7 +3,8 @@
 /// <reference path="./jsx/intrinsic-elements.d.ts" />
 
 type AttributeValue = number | string | Date | boolean | string[];
-type Children = {
+
+export type Children = {
     children?: AttributeValue
 };
 

--- a/src/elements.tsx
+++ b/src/elements.tsx
@@ -2,7 +2,7 @@
 /// <reference path="./jsx/events.d.ts" />
 /// <reference path="./jsx/intrinsic-elements.d.ts" />
 
-type AttributeValue = number | string | Date | boolean;
+type AttributeValue = number | string | Date | boolean | string[];
 type Children = {
     children?: AttributeValue
 };
@@ -115,15 +115,13 @@ export function createElement(name: string | CustomElementHandler,
     const children = attributes && attributes.children || contents;
 
     if (typeof name === 'function') {
-        // @ts-ignore: Figure this out
         return name(children ? { children, ...attributes } : attributes, contents);
     } else {
         const tagName = toKebabCase(name);
         if (isVoidElement(tagName) && !contents.length) {
             return `<${tagName}${attributesToString(attributes)}>`;
         } else {
-            // @ts-ignore: Figure this out
-            return `<${tagName}${attributesToString(attributes)}>${contentsToString(children)}</${tagName}>`;
+            return `<${tagName}${attributesToString(attributes)}>${contentsToString(contents)}</${tagName}>`;
         }
     }
 }

--- a/src/elements.tsx
+++ b/src/elements.tsx
@@ -4,9 +4,9 @@
 
 type AttributeValue = number | string | Date | boolean | string[];
 
-export type Children = {
-    children?: AttributeValue
-};
+export interface Children {
+    children?: AttributeValue;
+}
 
 export interface CustomElementHandler {
     (attributes: Attributes & Children, contents: string[]): string;

--- a/src/elements.tsx
+++ b/src/elements.tsx
@@ -3,9 +3,12 @@
 /// <reference path="./jsx/intrinsic-elements.d.ts" />
 
 type AttributeValue = number | string | Date | boolean;
+type Children = {
+    children?: string[]
+};
 
 export interface CustomElementHandler {
-    (attributes: Attributes | undefined, contents: string[]): string;
+    (attributes: Attributes & Children, contents: string[]): string;
 }
 
 export interface Attributes {
@@ -106,7 +109,7 @@ const isVoidElement = (tagName: string) => {
 };
 
 export function createElement(name: string | CustomElementHandler,
-    attributes: Attributes | undefined,
+    attributes: Attributes | undefined = {},
     ...contents: string[]) {
     if (typeof name === 'function') {
         return name(attributes, contents);

--- a/test/html-fragments.spec.tsx
+++ b/test/html-fragments.spec.tsx
@@ -15,22 +15,22 @@ const testEqual = (expected: string, actual: () => string, itImplementation: (ex
 };
 
 describe('Simple html structures', () => {
-    testEqual('<a href="test">a link</a>', () => <a href="test">a link</a>);
+    testEqual('<a href="test">a link</a>', () => <a href='test'>a link</a>);
     testEqual(`<ul>
     <li>1</li>
     <li>2</li>
     </ul>`, () => <ul>{[1, 2].map(li => <li>{li}</li>)}</ul>);
-    testEqual('<button onclick="doSomething"></button>', () => <button onclick="doSomething"></button>);
-    testEqual('<div class="class-a"></div>', () => <div class="class-a"></div>);
-    testEqual('<script src="jquery.js" integrity="sha256-123=" crossorigin="anonymous"></script>', () => <script src="jquery.js" integrity="sha256-123=" crossorigin="anonymous"></script>);
+    testEqual('<button onclick="doSomething"></button>', () => <button onclick='doSomething'></button>);
+    testEqual('<div class="class-a"></div>', () => <div class='class-a'></div>);
+    testEqual('<script src="jquery.js" integrity="sha256-123=" crossorigin="anonymous"></script>', () => <script src='jquery.js' integrity='sha256-123=' crossorigin='anonymous'></script>);
 });
 
 describe('Self-closing html tags', () => {
     testEqual('<area>', () => <area></area>);
     testEqual('<hr>', () => <hr></hr>);
     testEqual('<hr>content</hr>', () => <hr>content</hr>);
-    testEqual('<meta charset="utf8">', () => <meta charset="utf8"></meta>);
-    testEqual('<video autoplay></video>', () => <video autoplay=""></video>);
+    testEqual('<meta charset="utf8">', () => <meta charset='utf8'></meta>);
+    testEqual('<video autoplay></video>', () => <video autoplay=''></video>);
 });
 
 describe('Boolean attributes', () => {
@@ -41,7 +41,7 @@ describe('Boolean attributes', () => {
     testEqual('<input>', () => <input disabled={false}></input>);
     testEqual('<p draggable spellcheck hidden translate></p>', () => <p draggable spellcheck hidden translate></p>);
     testEqual('<p></p>', () => <p draggable={false} spellcheck={false} hidden={false} translate={false}></p>);
-    testEqual('<form novalidate></form>', () => <form novalidate></form>)
+    testEqual('<form novalidate></form>', () => <form novalidate></form>);
 });
 
 describe('Encoded attributes', () => {
@@ -57,9 +57,9 @@ describe('Encoded attributes', () => {
 });
 
 describe('Events', () => {
-    testEqual('<div onclick="click" onmouseover="mouseover" ondrag="ondrag"></div>', () => <div onclick="click" onmouseover="mouseover" ondrag="ondrag"></div>);
-    testEqual('<form onfocus="focus"><input onblur="blur"></form>', () => <form onfocus="focus"><input onblur="blur"></input></form>);
-    testEqual('<video onabort="abort" onseeking="seeking"></video>', () => <video onabort="abort" onseeking="seeking"></video>);
+    testEqual('<div onclick="click" onmouseover="mouseover" ondrag="ondrag"></div>', () => <div onclick='click' onmouseover='mouseover' ondrag='ondrag'></div>);
+    testEqual('<form onfocus="focus"><input onblur="blur"></form>', () => <form onfocus='focus'><input onblur='blur'></input></form>);
+    testEqual('<video onabort="abort" onseeking="seeking"></video>', () => <video onabort='abort' onseeking='seeking'></video>);
 });
 
 describe('Using a Date type attribute', () => {
@@ -77,15 +77,27 @@ describe('using a number attribute', () => {
 });
 
 describe('custom elements', () => {
-    testEqual('<custom-element a-custom-attr="value" custom-li-attr="li"></custom-element>', () => <customElement ACustomAttr="value" customLIAttr="li"></customElement>);
-    testEqual('<div some-data="s"></div>', () => <div some-data="s"></div>);
+    testEqual('<custom-element a-custom-attr="value" custom-li-attr="li"></custom-element>', () => <customElement ACustomAttr='value' customLIAttr='li'></customElement>);
+    testEqual('<div some-data="s"></div>', () => <div some-data='s'></div>);
 });
 
 describe('helper components', () => {
-    const Header: elements.CustomElementHandler = (attributes, contents) => <h1 {...attributes}>{contents}</h1>;
+    const Header: elements.CustomElementHandler = (attributes: elements.Attributes, contents) => <h1 {...attributes}>{contents}</h1>;
 
     function Button(attributes: elements.Attributes | undefined, contents: string[]) {
         return <button type='button' class='original-class' {...attributes}>{contents}</button>;
+    }
+
+    testEqual('<h1 class="title"><span>Header Text</span></h1>', () => <Header class='title'><span>Header Text</span></Header>);
+    testEqual('<button class="override" type="button"></button>', () => <Button class='override'/>);
+    testEqual('<button class="original-class" type="button">Button Text</button>', () => <Button>Button Text</Button>);
+});
+
+describe('React-style children', () => {
+    const Header: elements.CustomElementHandler = ({ children, ...attributes }: elements.Attributes) => <h1 {...attributes}>{children}</h1>;
+
+    function Button({ children, ...attributes }: elements.Attributes) {
+        return <button type='button' class='original-class' {...attributes}>{children}</button>;
     }
 
     testEqual('<h1 class="title"><span>Header Text</span></h1>', () => <Header class='title'><span>Header Text</span></Header>);


### PR DESCRIPTION
After using **typed-html** a while at [tailwind-webpack-starter](https://github.com/survivejs/tailwind-webpack-starter), I started missing React-style `children` as that would simplify some of the code and make it feel more familiar.

I see my editor applied some formatting changes to the code. I can revert those if you prefer. I guess ideally we would have Prettier set up in the project as that would solve these kind of problems.