### PR TITLE
feat(node): drop support for node 8 and 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release:major": "npm version major -m \"chore(release): %s\""
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "keywords": [
     "typescript",


### PR DESCRIPTION
BREAKING CHANGE: Support for Node > 12 is dropped (although it will still work)