### PR TITLE
Update element-types.d.ts to include additional img tag properties

### DIFF
--- a/src/jsx/element-types.d.ts
+++ b/src/jsx/element-types.d.ts
@@ -124,6 +124,9 @@ declare namespace JSX {
         ismap?: string;
         width?: string;
         height?: string;
+        decoding?: "sync" | "async" | "auto";
+        loading?: "eager" | "lazy";
+        srcset?: string;
     }
     interface HtmlInputTag extends HtmlTag {
         accept?: string;


### PR DESCRIPTION
Added some more <img> properties. Info at: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset