### PR TITLE
Added `mininput` attribute to HtmlInputTag

### DIFF
--- a/src/jsx/element-types.d.ts
+++ b/src/jsx/element-types.d.ts
@@ -141,6 +141,7 @@ declare namespace JSX {
         maxlength?: string;
         method?: string;
         min?: string;
+        minlength?: string;
         multiple?: string;
         name?: string;
         novalidate?: string | boolean;


### PR DESCRIPTION
I noticed the `mininput` attribute was missing on the HtmlInputTag. As it is only present on text, search, url, tel, email, and password inputs, I wasn't sure whether this was intentional, but I still opened this.

https://www.w3schools.com/tags/att_input_minlength.asp