### PR TITLE
fix: package.json module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "TypeSafe HTML templates using TypeScript. No need to learn a template library.",
   "main": "dist/src/elements.js",
-  "module": "dist/esm/elements.js",
+  "module": "dist/esm/src/elements.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/nicojs/typed-html"


### PR DESCRIPTION
I was trying to use this with Vite (which uses esbuild so ESM modules are used), but I kept getting this error:

```
Error: Failed to resolve entry for package "typed-html". The package may have incorrect main/module/exports specified in its package.json.
```

I tried to clone this repo and tried to build it, then I noticed that `"module"` in the `package.json` points to `dist/esm/elements.js`, which is wrong 'cause checking the `dist` folder after building, it's actually `dist/esm/src/elements.js`.